### PR TITLE
Cosmetic and UX fixes to Bot chat.

### DIFF
--- a/components/ChatInputComponent.js
+++ b/components/ChatInputComponent.js
@@ -13,6 +13,7 @@ export default class ChatInputComponent extends React.Component {
 
     // binds
     this.submit = this.submit.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   submit() {
@@ -20,6 +21,12 @@ export default class ChatInputComponent extends React.Component {
     if (text !== '') {
       this.setState({ text: '' });
       return this.props?.submit({ text });
+    }
+  }
+
+  handleKeyDown(e) {
+    if (e.keyCode == 13 && e.shiftKey) {
+      this.submit();
     }
   }
 
@@ -40,10 +47,10 @@ export default class ChatInputComponent extends React.Component {
                 onChange={(value) =>
                   this.setState({ text: value.target.value })
                 }
+                onKeyDown={this.handleKeyDown}
                 placeholder="Type here to talk with me..."
                 className="input"
                 multiline
-                rows={4}
                 InputProps={{ disableUnderline: true }}
               />
             </FormControl>
@@ -51,7 +58,7 @@ export default class ChatInputComponent extends React.Component {
           <div className="btn-container">
             {!this.props?.disabled && (
               <Button className="done" onClick={this.submit}>
-                Done
+                Send
               </Button>
             )}
           </div>

--- a/styles/components/chat-input/index.scss
+++ b/styles/components/chat-input/index.scss
@@ -1,7 +1,7 @@
 #chat-input {
     background-color: $message-input-bg-color;
     max-width: 410px;
-    min-height: 125px;
+    // min-height: 125px;
     width: 100%;
     display: flex;
     align-self: flex-start;
@@ -55,4 +55,8 @@
             @include font-family(10px, $message-input-information-tip-color);
         }
     }
+}
+
+.MuiInputBase-multiline {
+    padding: 16px 0 0 !important;
 }


### PR DESCRIPTION
shift+enter added, changed ‘done’ to ‘send’, and pulled cursor down to input line.  Resolves issue #5 and issue #3.